### PR TITLE
Issue/3: Maintenance Dockerfile and service definition 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM opennms/openjdk:8u131-jdk
 
-MAINTAINER Ronny Trommer <ronny@opennms.org>
+LABEL maintainer "Ronny Trommer <ronny@opennms.org>"
 
 ARG OPENNMS_VERSION=develop
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,41 @@
 version: '2'
+
+volumes:
+  psql.data:
+    driver: local
+  opennms.data:
+    driver: local
+
+networks:
+  opennms.net:
+    driver: bridge
+
 services:
-  db_data:
-    image: tianon/true
-    volumes:
-      - /var/lib/postgresql/data
   database:
+    container_name: opennms.psql
     image: postgres:9.6.1
     env_file:
       - .postgres.env
+    networks:
+      - opennms.net
+    volumes:
+      - psql.data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
-    depends_on:
-      - db_data
-    volumes_from:
-      - db_data:rw
-  opennms_data:
-    image: tianon/true
-    volumes:
-      - /opennms-data
+
   opennms:
+    container_name: opennms.hzn.core.web
     image: opennms/horizon-core-web:latest
     env_file:
       - .opennms.env
       - .postgres.env
+    networks:
+      - opennms.net
     depends_on:
       - database
-      - opennms_data
-    volumes_from:
-      - opennms_data:rw
     volumes:
-      - /myhost/opennms/etc:/opt/opennms/etc
+      - opennms.data:/opt/opennms/etc
+      - opennms.data:/opennms-data
     command: ["-s"]
     ports:
       - "8980:8980"

--- a/docker-opennms.service
+++ b/docker-opennms.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Dockerized OpenNMS Service
+Description=OpenNMS Horizon Core Web
 After=docker.service
 BindsTo=docker.service
 Conflicts=shutdown.target reboot.target halt.target

--- a/opennms-grafana-pris.yml
+++ b/opennms-grafana-pris.yml
@@ -1,36 +1,49 @@
 version: '2'
+
+volumes:
+  psql.data:
+    driver: local
+  opennms.data:
+    driver: local
+  pris.data:
+    driver: local
+  grafana.data:
+    driver: local
+
+networks:
+  opennms.net:
+    driver: bridge
+
 services:
-  db_data:
-    image: tianon/true
-    volumes:
-        - /var/lib/postgresql/data
   database:
+    container_name: opennms.psql
     image: postgres:9.6.1
+    environment:
+      - TZ=Europe/Berlin
     env_file:
       - .postgres.env
+    networks:
+      - opennms.net
+    volumes:
+      - psql.data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
-    depends_on:
-      - db_data
-    volumes_from:
-      - db_data:rw
-  opennms_data:
-    image: tianon/true
-    volumes:
-        - /var/log/opennms
-        - /var/opennms/rrd
-        - /var/opennms/reports
-        - /opt/opennms/etc
+
   opennms:
+    container_name: opennms.hzn.core.web
     image: opennms/horizon-core-web:latest
+    environment:
+      - TZ=Europe/Berlin
     env_file:
       - .opennms.env
       - .postgres.env
+    networks:
+      - opennms.net
     depends_on:
       - database
-      - opennms_data
-    volumes_from:
-      - opennms_data:rw
+    volumes:
+      - opennms.data:/opt/opennms/etc
+      - opennms.data:/opennms-data
     command: ["-s"]
     ports:
       - "8980:8980"
@@ -40,15 +53,32 @@ services:
       - "61616:61616"
       - "5817:5817"
       - "162:162/udp"
+
   pris:
+    container_name: opennms.pris
     image: opennms/pris:1.1.6
+    environment:
+      - TZ=Europe/Berlin
+    networks:
+      - opennms.net
+    volumes:
+      - pris.data:/opt/opennms-pris/requisitions
+      - pris.data:/opt/opennms-pris/scriptsteps
     ports:
       - "8000:8000"
+
   grafana:
+    container_name: opennms.grafana
     image: grafana/grafana:4.3.2
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - TZ=Europe/Berlin
     env_file:
       - .grafana.env
+    networks:
+      - opennms.net
+    volumes:
+      - grafana.data:/var/lib/grafana
+      - grafana.data:/var/log/grafana
+      - grafana.data:/etc/grafana
     ports:
       - "3000:3000"

--- a/opennms-grafana.yml
+++ b/opennms-grafana.yml
@@ -1,36 +1,47 @@
 version: '2'
+
+volumes:
+  psql.data:
+    driver: local
+  opennms.data:
+    driver: local
+  grafana.data:
+    driver: local
+
+networks:
+  opennms.net:
+    driver: bridge
+
 services:
-  db_data:
-    image: tianon/true
-    volumes:
-        - /var/lib/postgresql/data
   database:
+    container_name: opennms.psql
     image: postgres:9.6.1
+    environment:
+      - TZ=Europe/Berlin
     env_file:
       - .postgres.env
+    networks:
+      - opennms.net
+    volumes:
+      - psql.data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
-    depends_on:
-      - db_data
-    volumes_from:
-      - db_data:rw
-  opennms_data:
-    image: tianon/true
-    volumes:
-        - /var/log/opennms
-        - /var/opennms/rrd
-        - /var/opennms/reports
-        - /opt/opennms/etc
+
   opennms:
+    container_name: opennms.hzn.core.web
     image: opennms/horizon-core-web:latest
+    environment:
+      - TZ=Europe/Berlin
     env_file:
       - .opennms.env
       - .postgres.env
+    networks:
+      - opennms.net
     depends_on:
       - database
-      - opennms_data
-    volumes_from:
-      - opennms_data:rw
+    volumes:
+      - opennms.data:/opt/opennms/etc
+      - opennms.data:/opennms-data
     command: ["-s"]
     ports:
       - "8980:8980"
@@ -40,11 +51,19 @@ services:
       - "61616:61616"
       - "5817:5817"
       - "162:162/udp"
+
   grafana:
+    container_name: opennms.grafana
     image: grafana/grafana:4.3.2
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - TZ=Europe/Berlin
     env_file:
       - .grafana.env
+    networks:
+      - opennms.net
+    volumes:
+      - grafana.data:/var/lib/grafana
+      - grafana.data:/var/log/grafana
+      - grafana.data:/etc/grafana
     ports:
       - "3000:3000"

--- a/opennms-pris.yml
+++ b/opennms-pris.yml
@@ -1,36 +1,47 @@
 version: '2'
+
+volumes:
+  psql.data:
+    driver: local
+  opennms.data:
+    driver: local
+  pris.data:
+    driver: local
+
+networks:
+  opennms.net:
+    driver: bridge
+
 services:
-  db_data:
-    image: tianon/true
-    volumes:
-        - /var/lib/postgresql/data
   database:
+    container_name: opennms.psql
     image: postgres:9.6.1
+    environment:
+      - TZ=Europe/Berlin
     env_file:
       - .postgres.env
+    networks:
+      - opennms.net
+    volumes:
+      - psql.data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
-    depends_on:
-      - db_data
-    volumes_from:
-      - db_data:rw
-  opennms_data:
-    image: tianon/true
-    volumes:
-        - /var/log/opennms
-        - /var/opennms/rrd
-        - /var/opennms/reports
-        - /opt/opennms/etc
+
   opennms:
+    container_name: opennms.hzn.core.web
     image: opennms/horizon-core-web:latest
+    environment:
+      - TZ=Europe/Berlin
     env_file:
       - .opennms.env
       - .postgres.env
+    networks:
+      - opennms.net
     depends_on:
       - database
-      - opennms_data
-    volumes_from:
-      - opennms_data:rw
+    volumes:
+      - opennms.data:/opt/opennms/etc
+      - opennms.data:/opennms-data
     command: ["-s"]
     ports:
       - "8980:8980"
@@ -40,7 +51,16 @@ services:
       - "61616:61616"
       - "5817:5817"
       - "162:162/udp"
+
   pris:
+    container_name: opennms.pris
     image: opennms/pris:1.1.6
+    environment:
+      - TZ=Europe/Berlin
+    networks:
+      - opennms.net
+    volumes:
+      - pris.data:/opt/opennms-pris/requisitions
+      - pris.data:/opt/opennms-pris/scriptsteps
     ports:
       - "8000:8000"


### PR DESCRIPTION
Replace the deprecated maintainer with a label. Set a friendly name in the Systemd service file. Replaced the data containers with volumes using the local storage driver. Added a network for opennms internal service communication. Replaced the mounted localtime file with setting the TZ environment to set the timezone correctly.