### PR TITLE
issue/7: Update OpenJDK 1.8.0u131 to OpenJDK 1.8.0u141

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opennms/openjdk:8u131-jdk
+FROM opennms/openjdk:8u141-jdk
 
 LABEL maintainer "Ronny Trommer <ronny@opennms.org>"
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@
 
 ### latest
 
+* CentOS 7 with OpenJDK 8u141-jdk
+* Official PostgreSQL 9.6.1
+* Horizon 21 development snapshot
+
 ### 20.0.1-1
 
-* CentOS 7 with OpenJDK 8u131-jdk
+* CentOS 7 with OpenJDK 8u141-jdk
 * Official PostgreSQL 9.6.1
 * Horizon 20.0.1-1
 


### PR DESCRIPTION
Use latest CentOS 7 with OpenJDK 1.8.0 update 141