### PR TITLE
Add support for a Jetty WEB-INF overlay directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ defaults: &defaults
 references:
   container_config: &container_config
     docker:
-      - image: docker:18.03.1-ce-git
+      - image: docker:18.05.0-ce-git
 
   dockerhub_login: &dockerhub_login
     run:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 ## Horizon Version Tags
 
 * `bleeding`, daily bleeding edge version of Horizon 22 using OpenJDK latest
-<<<<<<< HEAD
-* `21.1.0-1`, `latest` is a reference to last stable release of Horizon using OpenJDK latest
-=======
 * `22.0.1-1`, `latest` is a reference to last stable release of Horizon using OpenJDK latest
 * `22.0.0-1`, using OpenJDK 8u171-jdk
 * `21.1.0-1`, using OpenJDK 8u161-jdk
->>>>>>> db79081... Release Horizon 22.0.1-1
 * `21.0.5-1`, using OpenJDK 8u161-jdk
 * `21.0.4-1`, using OpenJDK 8u161-jdk
 * `21.0.3-1`, using OpenJDK 8u161-jdk
@@ -80,8 +76,8 @@ IMPORTANT: Take care about configurations which can be changed through the Web U
 
 ## Requirements
 
-* docker 18.02.0-ce, build 89658be
-* docker-compose 1.17.0, build ac53b73
+* docker 18.05.0-ce, build 89658be
+* docker-compose 1.21.1, build 5a3f1a3
 * git
 
 ## Usage
@@ -175,6 +171,28 @@ Starting with `-i` or `-s` will run the `install -dis` command once to update th
 
 All options which do upgrades or start OpenNMS Horizon verify if the configuration is valid and pass the configuration test.
 
+## Using etc-overlay for custom configuration
+
+If you just want to maintain custom configuration files outside of OpenNMS, you can use an etc-overlay directory.
+All files in this directory are just copied into /opt/opennms/etc in the running container.
+You can just mount a local directory like this:
+
+```
+volumes:
+  - ./etc-overlay:/opt/opennms-etc-overlay
+```
+
+## Using jetty-overlay to customize Jetty WEBINF
+
+If you just want to maintain custom configuration files for the Jetty application container, you can use an jetty-overlay directory.
+All files in this directory are just copied into /opt/opennms/jetty-webapps/opennms/WEB-INF in the running container.
+You can just mount a local directory like this:
+
+```
+volumes:
+  - ./jetty-overlay:/opt/opennms-jetty-webinf-overlay
+```
+
 ## Support and Issues
 
 Please open issues in the [GitHub issue] section.
@@ -209,4 +227,3 @@ Using a Cassandra Cluster:
 [GitHub issue]: https://github.com/opennms-forge/docker-horizon-core-web
 [CircleCI]: https://circleci.com/gh/opennms-forge/docker-horizon-core-web
 [Web Chat]: https://chats.opennms.org/opennms-discuss
-[IRC]: irc://freenode.org/#opennms

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,6 +12,7 @@ OPENNMS_HOME=/opt/opennms
 OPENNMS_DATASOURCES_TPL=/root/opennms-datasources.xml.tpl
 OPENNMS_DATASOURCES_CFG=${OPENNMS_HOME}/etc/opennms-datasources.xml
 OPENNMS_OVERLAY_CFG=/opt/opennms-etc-overlay
+OPENNMS_OVERLAY_JETTY_WEBINF=/opt/opennms-jetty-webinf-overlay
 
 OPENNMS_UPGRADE_GUARD=${OPENNMS_HOME}/etc/do-upgrade
 OPENNMS_CONFIGURED_GUARD=${OPENNMS_HOME}/etc/configured
@@ -94,6 +95,13 @@ applyOverlayConfig() {
     cp -r ${OPENNMS_OVERLAY_CFG}/* ${OPENNMS_HOME}/etc || exit ${E_INIT_CONFIG}
   else
     echo "No custom config found in ${OPENNMS_OVERLAY_CFG}. Use default configuration."
+  fi
+
+  if [ "$(ls -A ${OPENNMS_OVERLAY_JETTY_WEBINF})" ]; then
+    echo "Apply custom Jetty WEB-INF configuration from ${OPENNMS_OVERLAY_JETTY_WEBINF}."
+    cp -r ${OPENNMS_OVERLAY_JETTY_WEBINF}/* ${OPENNMS_HOME}/jetty-webapps/opennms/WEB-INF || exit ${E_INIT_CONFIG}
+  else
+    echo "No custom Jetty WEB-INF config found in ${OPENNMS_OVERLAY_JETTY_WEBINF}. Use default configuration."
   fi
 }
 


### PR DESCRIPTION
Create a directory which is used to overwrite files in /opt/opennms/jetty-webapps/opennms/WEB-INF.

Resolves #28 