### PR TITLE
Typo in newts.properties.tpl file

### DIFF
--- a/assets/newts.properties.tpl
+++ b/assets/newts.properties.tpl
@@ -29,7 +29,7 @@ org.opennms.newts.config.hostname=${OPENNMS_CASSANDRA_HOSTNAMES}
 org.opennms.newts.config.keyspace=${OPENNMS_CASSANDRA_KEYSPACE}
 org.opennms.newts.config.port=${OPENNMS_CASSANDRA_PORT}
 org.opennms.newts.config.username=${OPENNMS_CASSANDRA_USERNAME}
-org.opennms.newts.config.password=${OPENNMS_CASSANDRA_PASSWORD}`
+org.opennms.newts.config.password=${OPENNMS_CASSANDRA_PASSWORD}
 
 
 ###### Time Series Strategy ####


### PR DESCRIPTION
With this typo is not possible to connect opennms container to cassandra.