### PR TITLE
Fix docker-entrypoint typo

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -120,7 +120,7 @@ applyOverlayConfig() {
 applyKarafDebugLogging() {
   if [ -n "${KARAF_DEBUG_LOGGING}" ]; then
     echo "Updating Karaf debug logging"
-    for log in $(sed "s/,/ /g" <<< "${KARAF_DEBUG_LOGGING{"); do
+    for log in $(sed "s/,/ /g" <<< "${KARAF_DEBUG_LOGGING}"); do
       logUnderscored=${log//./_}
       echo "log4j2.logger.${logUnderscored}.level = DEBUG" >> "${OPENNMS_HOME}"/etc/org.ops4j.pax.logging.cfg
       echo "log4j2.logger.${logUnderscored}.name = $log" >> "${OPENNMS_HOME}"/etc/org.ops4j.pax.logging.cfg


### PR DESCRIPTION
Fix typo in the docker-entrypoint.sh:
```
docker-entrypoint.sh: line 228: unexpected EOF while looking for matching `"'
docker-entrypoint.sh: line 232: syntax error: unexpected end of file
```
https://chat.opennms.com/opennms/pl/gh3n8u8fqfdn9yns31nxo9z83r

