### PR TITLE
HZN-1556: Introduce a cachable intermediate image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Version Tags
 
 * `bleeding`, daily bleeding edge version of Horizon 24 using OpenJDK 11
-* `23.0.4-1`, last stable release of Horizon using OpenJDK 8
+* `24.0.0`, last stable release of Horizon using OpenJDK 11
 
 ## General Project Information
 

--- a/build_container_image.sh
+++ b/build_container_image.sh
@@ -6,18 +6,14 @@ source ./config.sh
 # shellcheck source=registry-config.sh
 source ./registry-config.sh
 
-if [ -d images ]; then
-  rm -rf mages/*
+if [[ -d images ]]; then
+  rm -rf images/*
 fi
 
 docker build -t "${CONTAINER_PROJECT}" \
   --build-arg BUILD_DATE="${BUILD_DATE}" \
   --build-arg BASE_IMAGE="${BASE_IMAGE}" \
   --build-arg BASE_IMAGE_VERSION="${BASE_IMAGE_VERSION}" \
-  --build-arg CONFD_VERSION="${CONFD_VERSION}" \
-  --build-arg CONFD_URL="${CONFD_URL}" \
-  --build-arg REPO_RPM="${REPO_RPM}" \
-  --build-arg REPO_KEY_URL="${REPO_KEY_URL}" \
   --build-arg VERSION="${VERSION}" \
   --build-arg PACKAGES="${PACKAGES}" \
   --build-arg ONMS_PACKAGES="${ONMS_PACKAGES}" \

--- a/config.sh
+++ b/config.sh
@@ -6,8 +6,8 @@
 CONTAINER_PROJECT="horizon-core-web"
 
 # Base Image Dependency
-BASE_IMAGE="opennms/openjdk"
-BASE_IMAGE_VERSION="11.0.2.7"
+BASE_IMAGE="opennms/base-horizon"
+BASE_IMAGE_VERSION="jdk11-1.0.0"
 BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%S%z")"
 
 # Horizon version
@@ -17,31 +17,11 @@ VERSION="25.0.0-SNAPSHOT"
 IMAGE_VERSION=("${VERSION}")
 
 # Add Docker tag when build in CircleCI with build number
-if [ -n "${CIRCLE_BUILD_NUM}" ]; then
+if [[ -n "${CIRCLE_BUILD_NUM}" ]]; then
   IMAGE_VERSION+=("${VERSION}-cb.${CIRCLE_BUILD_NUM}")
 fi
 
-REPO_HOST="yum.opennms.org"
-REPO_RELEASE="develop"
-REPO_RPM="https://${REPO_HOST}/repofiles/opennms-repo-${REPO_RELEASE}-rhel7.noarch.rpm"
-REPO_KEY_URL="https://${REPO_HOST}/OPENNMS-GPG-KEY"
-CONFD_VERSION="0.16.0"
-CONFD_URL="https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64"
-
-# System Package dependencies
-PACKAGES="wget
-          rsync
-          gettext"
-
-# OpenNMS Horizon dependencies
-PACKAGES="${PACKAGES}
-          rrdtool
-          https://yum.opennms.org/stable/rhel7/jicmp/jicmp-2.0.3-1.el7.centos.x86_64.rpm
-          https://yum.opennms.org/stable/rhel7/jicmp6/jicmp6-2.0.2-1.el7.centos.x86_64.rpm
-          perl-XML-Twig
-          perl-libwww-perl
-          jrrd2
-          R-core"
+PACKAGES="https://yum.opennms.org/repofiles/opennms-repo-develop-rhel7.noarch.rpm"
 
 #
 # If you want to install packages from the official repository, add your packages here.


### PR DESCRIPTION
Introduce a cachable intermediate image with all external RPM dependencies introduced in [HZN-1556](https://issues.opennms.org/browse/HZN-1556). The base image is maintained [here](https://github.com/opennms-forge/opennms-base-container/tree/master/projects).